### PR TITLE
Add info about vite

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,15 @@ The `SwapWidget` component will render in whichever supported locale is passed t
 
       import { SwapWidget } from '@uniswap/widgets/index.js'
       import '@uniswap/widgets/dist/fonts.css'
+- When using with `vite`, you need to include folowwing polyfills in `vite.config`:
+
+      resolve: {
+            alias: {
+              jsbi: path.resolve(__dirname, "./node_modules/jsbi/dist/jsbi-cjs.js"),
+              "~@fontsource/ibm-plex-mono": "@fontsource/ibm-plex-mono",
+              "~@fontsource/inter": "@fontsource/inter",
+            },
+          },
 
 ### Additional documentation
 


### PR DESCRIPTION
When using widget with `vite` it throws errors about missing fonts (`[plugin:vite:css] [postcss] ENOENT: no such file or directory, open '~@fontsource/ibm-plex-mono/400.css'
`) or about missing modules (e.g. `Uncaught Error: Could not parse fraction at Function.tryParseFraction (fraction.ts:38:11)`)

Source: https://github.com/Uniswap/widgets/issues/586